### PR TITLE
Add toolbar to zoomed avatar - Refresh/Close

### DIFF
--- a/html/templates/zoomedAvatar.html
+++ b/html/templates/zoomedAvatar.html
@@ -1,4 +1,7 @@
 <div class="qol-extension-window" id="qol-zoomed-avatar-container">
     <img src="" alt="" id="qol-zoomed-avatar-image">
-    <div  id="qol-zoomed-avatar-refresh" class="menu_button fa-solid fa-arrows-rotate fa-fw interactable" tabindex="0" role="button"></div>
+    <div class="flex-container" id="qol-zoomed-avatar-toolbar">
+        <div  id="qol-zoomed-avatar-close" class="menu_button fa-solid fa-times fa-fw interactable" tabindex="0" role="button"></div>
+        <div  id="qol-zoomed-avatar-refresh" class="menu_button fa-solid fa-arrows-rotate fa-fw interactable" tabindex="0" role="button"></div>
+    </div>
 </div>

--- a/html/templates/zoomedAvatar.html
+++ b/html/templates/zoomedAvatar.html
@@ -1,3 +1,4 @@
 <div class="qol-extension-window" id="qol-zoomed-avatar-container">
     <img src="" alt="" id="qol-zoomed-avatar-image">
+    <div  id="qol-zoomed-avatar-refresh" class="menu_button fa-solid fa-arrows-rotate fa-fw interactable" tabindex="0" role="button"></div>
 </div>

--- a/index.js
+++ b/index.js
@@ -608,8 +608,7 @@ eventSource.on(eventTypes.WORLDINFO_SCAN_DONE, function (/** @type {ScannedWIEnt
 
 // * MARK:Initialize Extension
 
-(async function initExtension() {
-
+$(async function () {
 	if (!context().extensionSettings[extensionName]) {
 	    context().extensionSettings[extensionName] = structuredClone(defaultSettings);
 	}
@@ -629,4 +628,4 @@ eventSource.on(eventTypes.WORLDINFO_SCAN_DONE, function (/** @type {ScannedWIEnt
 	await loadHTMLSettings();
 	setSettings();
 	await loadQOLFeatures();
-})();
+});

--- a/index.js
+++ b/index.js
@@ -209,6 +209,7 @@ const settingsCallbacks = {
 		const enableFeature = !forceUnable && extensionSettings.features.zoomCharacterAvatar;
 
 		setRootCSSVariables('--qol-zoomed-avatar-container-display', enableFeature ? 'flex' : 'none');
+		setRootCSSVariables('--qol-st-zoomed-avatar-container-display', enableFeature ? 'none' : 'flex');
 
 		if (enableFeature) zoomCharacterAvatar();
 	},
@@ -303,6 +304,17 @@ function getCharacterThumbnailFromMess(mess) {
 	return {char: character, avatar, fallbackAvatar};
 }
 
+function getLocalStorageVar(var_name, {def_value = ''}) {
+	let localStorageVisibility = localStorage.getItem(var_name);
+
+	if (!localStorageVisibility)
+		localStorage.setItem(var_name, def_value);
+
+	localStorageVisibility = localStorage.getItem(var_name);
+
+	return localStorageVisibility;
+}
+
 /**	Modifies a function to wrap it in a function that first executes a callback and THEN the original function.
 	@param {Function} [originalFunction]
 	originalFunction:
@@ -371,7 +383,7 @@ function triggerRegenerate() {
 function zoomCharacterAvatar() {
 	if (!extensionSettings.enabled ||
 		!extensionSettings.features.zoomCharacterAvatar
-	) return;
+	) return setRootCSSVariables('--qol-zoomed-avatar-container-display', 'none');
 
 	if (!chat?.length) return setRootCSSVariables('--qol-zoomed-avatar-container-display', 'none');
 
@@ -379,8 +391,12 @@ function zoomCharacterAvatar() {
 	const {char, avatar, fallbackAvatar} = getCharacterThumbnailFromMess(lastMes);
 
 	if (!avatar) return setRootCSSVariables('--qol-zoomed-avatar-container-display', 'none');
-	
-	setRootCSSVariables('--qol-zoomed-avatar-container-display', 'flex');
+
+	const localStorageVisibility = getLocalStorageVar('qol-zoomed-avatar-display', {
+		def_value: extensionSettings.features.zoomCharacterAvatar ? 'flex' : 'none'
+	});
+
+	setRootCSSVariables('--qol-zoomed-avatar-container-display', localStorageVisibility);
 	$('#qol-zoomed-avatar-image').data('fallback-img', fallbackAvatar);
 	$('#qol-zoomed-avatar-image').prop('src', `${avatar}?cb=${Date.now()}`);
 	$('#qol-zoomed-avatar-image').prop('alt', char?.name ?? "");
@@ -430,6 +446,7 @@ async function loadQOLFeatures() {
 
 	$('#sheld').append(zoomedAvatar);
 	$('#qol-zoomed-avatar-refresh').on('click', zoomCharacterAvatar);
+
 	$('#qol-zoomed-avatar-image').on('error', function() {
 		log('Error - Avatar could not load, using thumbnail');
 
@@ -439,6 +456,21 @@ async function loadQOLFeatures() {
 		if (src === fallback) return log('Error - Thumbnail could not load');
 
 		$(this).prop('src', fallback);
+	});
+
+	setRootCSSVariables('--qol-zoomed-avatar-container-display', getLocalStorageVar('qol-zoomed-avatar-display', {
+		def_value: extensionSettings.features.zoomCharacterAvatar ? 'flex' : 'none'
+	}));
+
+	$('#qol-zoomed-avatar-close').on('click', function () {
+		localStorage.setItem('qol-zoomed-avatar-display', 'none');
+		setRootCSSVariables('--qol-zoomed-avatar-container-display', 'none');
+	});
+
+	$('#chat').on('click', '.mes .avatar', function () {
+		if (!extensionSettings.enabled || !extensionSettings.features.zoomCharacterAvatar) return;
+		localStorage.setItem('qol-zoomed-avatar-display', 'flex');
+		setRootCSSVariables('--qol-zoomed-avatar-container-display', 'flex');
 	});
 
 	zoomCharacterAvatar();

--- a/index.js
+++ b/index.js
@@ -45,6 +45,8 @@ const {
 	getThumbnailUrl,
 	chat,
 	groups,
+	groupId,
+	characterId,
 	characters,
 	powerUserSettings,
     t
@@ -206,7 +208,7 @@ const settingsCallbacks = {
 	zoomCharacterAvatar: function (forceUnable = false) {
 		const enableFeature = !forceUnable && extensionSettings.features.zoomCharacterAvatar;
 
-		setRootCSSVariables('--qol-zoomed-avatar-container-display', enableFeature ? 'block' : 'none');
+		setRootCSSVariables('--qol-zoomed-avatar-container-display', enableFeature ? 'flex' : 'none');
 
 		if (enableFeature) zoomCharacterAvatar();
 	},
@@ -268,6 +270,8 @@ function characterFromMessage(mess) {
 		char = Object.entries(powerUserSettings.personas)
 			.map(([k, v]) => ({name: v, avatar: k}))
 			.find(p => p.name === mess.name);
+	else if (groupId === null && characterId !== undefined)
+		char = characters[characterId];
 	else
 		char = characters.find(c => c.name === mess.name);
 
@@ -376,9 +380,9 @@ function zoomCharacterAvatar() {
 
 	if (!avatar) return setRootCSSVariables('--qol-zoomed-avatar-container-display', 'none');
 	
-	setRootCSSVariables('--qol-zoomed-avatar-container-display', 'block');
+	setRootCSSVariables('--qol-zoomed-avatar-container-display', 'flex');
 	$('#qol-zoomed-avatar-image').data('fallback-img', fallbackAvatar);
-	$('#qol-zoomed-avatar-image').prop('src', avatar);
+	$('#qol-zoomed-avatar-image').prop('src', `${avatar}?cb=${Date.now()}`);
 	$('#qol-zoomed-avatar-image').prop('alt', char?.name ?? "");
 
 	log("zoomCharacterAvatar()");
@@ -425,6 +429,7 @@ async function loadQOLFeatures() {
 	const zoomedAvatar = await HTML_TEMPLATES.get('zoomedAvatar');
 
 	$('#sheld').append(zoomedAvatar);
+	$('#qol-zoomed-avatar-refresh').on('click', zoomCharacterAvatar);
 	$('#qol-zoomed-avatar-image').on('error', function() {
 		log('Error - Avatar could not load, using thumbnail');
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
     "js": "index.js",
     "css": "style.css",
     "author": "Leandro Jofre",
-    "version": "0.5.6",
+    "version": "0.5.7",
     "minimum_client_version": "1.15.0",
     "homePage": "https://github.com/leandrojofre/SillyTavern-QOL.git",
     "auto_update": true

--- a/style.css
+++ b/style.css
@@ -1,5 +1,6 @@
 :root {
 	--qol-zoomed-avatar-container-display: flex;
+	--qol-st-zoomed-avatar-container-display: none;
 }
 
 @media screen and (max-width: 1000px) {
@@ -8,6 +9,10 @@
 			display: none;
 		}
 	}
+}
+
+div.zoomed_avatar:has(.zoomed_avatar_img) {
+	display: var(--qol-st-zoomed-avatar-container-display) !important;
 }
 
 .qol-extension-window {
@@ -67,15 +72,24 @@
 	width: -webkit-fill-available;
 }
 
-#qol-zoomed-avatar-refresh {
+#qol-zoomed-avatar-toolbar {
 	position: absolute;
+	gap: 0px;
     left: 0;
     top: 0;
-	margin: 0;
-	padding: 3px;
-    aspect-ratio: 1;
-    border: none;
-	background-color: rgba(0 0 0 / 70%);
+
+	.menu_button {
+		margin: 0;
+		padding: 3px;
+		aspect-ratio: 1;
+		border: rgba(0 0 0 / 60%);
+		background-color: rgba(0 0 0 / 60%);
+	}
+
+	.menu_button:hover {
+		background-color: rgba(255 255 255 / 60%);
+		color: black;
+	}
 }
 
 #qol-zoomed-avatar-container {

--- a/style.css
+++ b/style.css
@@ -1,5 +1,5 @@
 :root {
-	--qol-zoomed-avatar-container-display: block;
+	--qol-zoomed-avatar-container-display: flex;
 }
 
 @media screen and (max-width: 1000px) {
@@ -60,16 +60,28 @@
 		display: none !important;
 	}
 
-	#qol-zoomed-avatar-image {
-		position: fixed;
-		bottom: 0;
-		left: 0;
-		width: calc((100vw - var(--sheldWidth)) / 2 - 1px);
-	}
+}
+
+#qol-zoomed-avatar-image {
+	width: 100%;
+	width: -webkit-fill-available;
+}
+
+#qol-zoomed-avatar-refresh {
+	position: absolute;
+    left: 0;
+    top: 0;
+	margin: 0;
+	padding: 3px;
+    aspect-ratio: 1;
+    border: none;
+	background-color: rgba(0 0 0 / 70%);
 }
 
 #qol-zoomed-avatar-container {
 	display: var(--qol-zoomed-avatar-container-display);
-    width: 0;
-    height: 0;
+	position: fixed;
+	bottom: 0;
+	left: 0;
+	width: calc((100vw - var(--sheldWidth)) / 2 - 1px);
 }


### PR DESCRIPTION
## Changes
- Now you can refresh the image of the zoomed avatar, in case it was updated and it didn't refresh automatically.
- Now you can close the zoomed avatar. It is independant to the settings menu feature, it will open again if you click any avatar in a chat message, replacing ST's zoomed avatar. It will swap back to ST's avatar if you disable the feature from the settings.

## Commits
- [Feat](https://github.com/leandrojofre/SillyTavern-QOL/pull/49/commits/67ad9a1e456ff2c192c3611647efe3173b131f9e) - Allow to refresh the image of the zoomend avatar
- [Feat](https://github.com/leandrojofre/SillyTavern-QOL/pull/49/commits/b67ff30797e6191b5f2ce069be9afb8764ef2815) - Allow to close the zoomed avatar
- [Update](https://github.com/leandrojofre/SillyTavern-QOL/pull/49/commits/fda62e53fa56b49035e31e84ba5371df2838f6b4) - Use JQuery to load the extension
- [Update manifest.json](https://github.com/leandrojofre/SillyTavern-QOL/pull/49/commits/4732037c823f78e80df6c3e4b76a0250440159b3)