### PR TITLE
Set collapse newlines to false by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ const defaultSettings = {
 		zoomCharacterAvatar: true,
 		simpleUserInput: false,
 		showActivatedWiEntries: true,
-		collapseNewlines: true,
+		collapseNewlines: false,
 	},
 	debug: false
 };

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
     "js": "index.js",
     "css": "style.css",
     "author": "Leandro Jofre",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "minimum_client_version": "1.15.0",
     "homePage": "https://github.com/leandrojofre/SillyTavern-QOL.git",
     "auto_update": true


### PR DESCRIPTION
## Commit
- [Fix](https://github.com/leandrojofre/SillyTavern-QOL/pull/53/commits/3afc6e6e4709fca7819e4b63f410de6fba594c76) - Set collapse newlines to false by default