### PR TITLE
Allow custom samplers in the Custom OAI Compatible (CC) endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import { getUserAvatar } from "../../../personas.js";
 import { formatCharacterAvatar, isGenerating } from "../../../../script.js";
 import { group_activation_strategy } from '../../../group-chats.js';
-import {collapseNewlines} from "../../../power-user.js";
+import { copyText } from '../../../utils.js';
 
 /** @type {Function} */
 toastr.error
@@ -310,6 +310,15 @@ function setRootCSSVariables(key = '', value = '') {
 }
 
 /**
+ * Set user clipboard
+ * @param {string} text
+ * @returns {Promise<void>}
+ */
+async function setClipboard(text = '') {
+    return await copyText(text);
+}
+
+/**
  * @param {object} mess
  * @returns {boolean|object}
  */
@@ -524,13 +533,20 @@ async function loadQOLFeatures() {
 	});
 
 	zoomCharacterAvatar();
+
+	$(document).on('click', '#qol-custom-samplers-list .sampler-key', function(e) {
+		const text = $(e.currentTarget)?.text() ?? '';
+
+		setClipboard(text);
+		toastr.info('Sampler key sent to the clipboard', extensionName);
+	});
 }
 
 // * MARK:Slash Commands
 
 const ENUMS_PROVIDER = {
 	customSamplersSet: () => Object
-		.keys(extensionSettings.customSamplers ?? [])
+		.keys(extensionSettings.customSamplers ?? {})
 		.map(key => new SlashCommandEnumValue(key))
 };
 
@@ -692,6 +708,7 @@ function registerSlashCommands() {
 					name: 'key',
 					description: 'Key of the custom parameter to add to the generation request body. It must be JSON compatible.',
 					typeList: [ARGUMENT_TYPE.STRING],
+					enumProvider: ENUMS_PROVIDER.customSamplersSet,
 					isRequired: true
 				})
 			],

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ toastr.success
 toastr.info
 
 /**
- * @typedef {object} ExtensionSettingsFeatures
+ * @typedef {Object} ExtensionSettingsFeatures
  * @property {boolean} quickRegenerate
  * @property {boolean} quickRegenerateAutoHide
  * @property {boolean} playErrorSound
@@ -25,17 +25,17 @@ toastr.info
  * @property {boolean} showActivatedWiEntries
  * @property {boolean} collapseNewlines
  *
- * @typedef {object} ExtensionSettings
+ * @typedef {Object} ExtensionSettings
  * @property {boolean} enabled
  * @property {number} soundVolume
  * @property {ExtensionSettingsFeatures} features
- * @property {object} customSamplers
+ * @property {Object} customSamplers
  * @property {boolean} debug
  */
 
 // declare type
 /**
- * @typedef {object} WIEntry
+ * @typedef {Object} WIEntry
  * @property {number} uid
  * @property {string} world
  * @property {string} comment
@@ -45,10 +45,10 @@ toastr.info
  * @property {boolean} vectorized
  * @property {boolean} constant
  *
- * @typedef {object} ScannedWIEntries
- * @property {object} [activated]
+ * @typedef {Object} ScannedWIEntries
+ * @property {Object} [activated]
  * @property {Map} [activated.entries]
- * @property {object} [new]
+ * @property {Object} [new]
  * @property {Array<WIEntry>} [new.successful]
  */
 
@@ -78,7 +78,8 @@ const {
 } = context();
 
 const {
-	lodash
+	lodash,
+	yaml
 } = SillyTavern.libs;
 
 const extensionName = "SillyTavern-QOL";
@@ -918,6 +919,40 @@ eventSource.makeFirst(eventTypes.GENERATE_AFTER_DATA, function (arg) {
 		}
 	}
 });
+
+eventSource.makeFirst(eventTypes.CHAT_COMPLETION_SETTINGS_READY, function (arg) {
+    if (!extensionSettings.enabled) return;
+
+	log(eventTypes.CHAT_COMPLETION_SETTINGS_READY, arg);
+
+	const doAddCustomSamplers = extensionSettings.customSamplers && Object.keys(extensionSettings.customSamplers).length > 0;
+
+	if (doAddCustomSamplers) {
+		const cleanSamplers = lodash.cloneDeep(extensionSettings.customSamplers);
+		const otherSamplers = {};
+
+		for (const key of Object.keys(arg ?? {})) {
+			if (cleanSamplers[key] !== undefined)
+				otherSamplers[key] = structuredClone(cleanSamplers[key]);
+
+			delete cleanSamplers[key];
+		}
+
+		log('Custom OAI compatible samplers OBJ', { otherSamplers, cleanSamplers });
+
+		Object.assign(arg, otherSamplers);
+
+		if (Object.keys(cleanSamplers).length) {
+			const customSamplers = yaml.parse(arg?.custom_include_body || '{}');
+			const mergedCustomSamplers = Object.assign({}, customSamplers, cleanSamplers);
+			const yamlCustomSamplers = yaml.stringify(mergedCustomSamplers);
+
+			log('Custom OAI compatible samplers YAML', { customSamplers, cleanSamplers, mergedCustomSamplers, yamlCustomSamplers });
+
+			arg.custom_include_body = yamlCustomSamplers;
+		}
+	}
+})
 
 /**
  * @param {WIEntry} entry

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
     "js": "index.js",
     "css": "style.css",
     "author": "Leandro Jofre",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "minimum_client_version": "1.15.0",
     "homePage": "https://github.com/leandrojofre/SillyTavern-QOL.git",
     "auto_update": true

--- a/source/html/templates/customSamplerRow.html
+++ b/source/html/templates/customSamplerRow.html
@@ -1,11 +1,11 @@
 <div>
     <div class="flex-container border bg-ui general-row">
-        <span class="sampler-key bg-ui-darker flex1 text-quote-color"></span>
+        <span class="sampler-key cursor-pointer bg-ui-darker flex1 text-quote-color" title="Copy sampler key on the clipboard"></span>
         <span class="sampler-value border-left flex1"></span>
     </div>
 
     <div class="flex-container border bg-ui list-dictionary-row">
-        <span class="sampler-key bg-ui-darker flex1 text-quote-color"></span>
+        <span class="sampler-key cursor-pointer bg-ui-darker flex1 text-quote-color" title="Copy sampler key on the clipboard"></span>
         <div class="sampler-value border-left flex1 flex-container flex-column scroll max-h-20">
             <div class="flex-container prop-item d-none prop-template">
                 <span class="flex1 prop-key text-quote-color"></span>

--- a/style.css
+++ b/style.css
@@ -119,6 +119,10 @@ div.zoomed_avatar:has(.zoomed_avatar_img) {
         padding-left: 10px;
     }
 
+	.cursor-pointer {
+		cursor: pointer;
+	}
+
 	.d-none {
 		display: none !important;
 	}


### PR DESCRIPTION
## Changes
- Clicking in the sampler names on the UI list will put them in your clipboard.
- `/qol-add-custom-sampler key={sampler-key}` will autocomplete with existing sampler names.
- The Custom OAI Compatible endpoint of Chat Completions will now use the samplers set with `/qol-add-custom-sampler`.
> Sadly, none of the other endpoints for Chat Completions expose a way for extensions to modify request parameters. Only Text Completions allow it on all API Types.