### PR TITLE
Allow to prevent accidentally closing ST on mobile go back gesture

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,6 @@ toastr.info
  * @property {boolean} debug
  */
 
-// declare type
 /**
  * @typedef {Object} WIEntry
  * @property {number} uid
@@ -211,7 +210,7 @@ const settingsCallbacks = {
 	},
 
 	/**	Enables/Disables the quick regenerate button.
-		@param {Boolean} [forceUnable=false]
+		@param {boolean} [forceUnable=false]
 		forceUnable:
 		- If true, forces features.quickRegenerate to be disabled.
 	*/
@@ -251,7 +250,7 @@ const settingsCallbacks = {
 	},
 
 	/**	Enables/Disables the zoom in avatar feature.
-		@param {Boolean} [forceUnable=false]
+		@param {boolean} [forceUnable=false]
 		forceUnable:
 		- If true, forces features.quickRegenerate to be disabled.
 	*/
@@ -320,8 +319,8 @@ async function setClipboard(text = '') {
 }
 
 /**
- * @param {object} mess
- * @returns {boolean|object}
+ * @param {Object} mess
+ * @returns {boolean|Object}
  */
 function characterFromMessage(mess) {
 	let char = {};
@@ -405,7 +404,7 @@ function playAudio(audio) {
 
 /**	Hides the Continue button from the right side of the input area.
 	If the extension is disabled, "hideRegenerateButton" will always hide the button.
-	@param {Boolean} [hide=true]
+	@param {boolean} [hide=true]
 	hide:
 	- Whether or not to hide the retry button.
 */
@@ -603,7 +602,7 @@ async function updateCustomSamplersList() {
 }
 
 /**
- * @param {object} namedArgs
+ * @param {Object} namedArgs
  * @param {string} unnamedArg
  * @returns {string}
  */
@@ -639,7 +638,7 @@ function addCustomSamplerCommand(namedArgs, unnamedArg = '') {
 }
 
 /**
- * @param {object} namedArgs
+ * @param {Object} namedArgs
  * @param {string} unnamedArg
  * @returns {string}
  */
@@ -666,7 +665,7 @@ function getCustomSamplerCommand(namedArgs, unnamedArg = '') {
 }
 
 /**
- * @param {object} namedArgs
+ * @param {Object} namedArgs
  * @param {string} unnamedArg
  * @returns {string}
  */
@@ -983,7 +982,7 @@ eventSource.on(eventTypes.GENERATE_AFTER_COMBINE_PROMPTS, async function (args) 
 	 * @typedef {JQuery<HTMLElement>} EntryGroup
 	 */
 
-	/** @type {object} */
+	/** @type {Object} */
 	const entriesGroupedByWorld = {};
 
 	activatedWiEntries.sort((a, b) => {

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ toastr.info
  * @property {boolean} simpleUserInput
  * @property {boolean} showActivatedWiEntries
  * @property {boolean} collapseNewlines
+ * @property {boolean} preventPageNavigation
  *
  * @typedef {Object} ExtensionSettings
  * @property {boolean} enabled
@@ -55,12 +56,13 @@ toastr.info
 
 const context = () => SillyTavern.getContext();
 const {
+	stopGeneration,
+	getThumbnailUrl,
+	isMobile,
     saveSettingsDebounced,
 	extensionSettings: extension_settings,
-	stopGeneration,
 	eventSource,
 	eventTypes,
-	getThumbnailUrl,
 	chat,
 	groups,
 	groupId,
@@ -99,6 +101,7 @@ const defaultSettings = {
 		simpleUserInput: false,
 		showActivatedWiEntries: true,
 		collapseNewlines: false,
+		preventPageNavigation: false,
 	},
 	customSamplers: {},
 	debug: false
@@ -156,7 +159,7 @@ async function loadHTMLSettings() {
 	$("#qol-simple-user-input").on("input", settingsBooleanButton);
 	$("#qol-simple-collapse-newlines").on("input", settingsBooleanButton);
 	$("#qol-show-activated-wi-entries").on("input", settingsBooleanButton);
-	$("#qol-remove-names-from-stop-strings").on("input", settingsBooleanButton);
+	$("#qol-prevent-page-navigation").on("input", settingsBooleanButton);
 
 	$("#qol-quick-retry").on("input", settingsBooleanButton);
 	$("#qol-quick-retry-autohide").on("input", settingsBooleanButton);
@@ -175,6 +178,7 @@ function setSettings() {
 	$("#qol-simple-user-input").prop("checked", extensionSettings.features.simpleUserInput).trigger("input");
 	$("#qol-simple-collapse-newlines").prop("checked", extensionSettings.features.collapseNewlines).trigger("input");
 	$("#qol-show-activated-wi-entries").prop("checked", extensionSettings.features.showActivatedWiEntries).trigger("input");
+	$("#qol-prevent-page-navigation").prop("checked", extensionSettings.features.preventPageNavigation).trigger("input");
 
 	$("#qol-quick-retry").prop("checked", extensionSettings.features.quickRegenerate).trigger("input");
 	$("#qol-quick-retry-autohide").prop("checked", extensionSettings.features.quickRegenerateAutoHide).trigger("input");
@@ -214,12 +218,12 @@ const settingsCallbacks = {
 		forceUnable:
 		- If true, forces features.quickRegenerate to be disabled.
 	*/
-	quickRegenerate: function (forceUnable = false) {
+	quickRegenerate: function(forceUnable = false) {
 		hideRegenerateButton(forceUnable || !extensionSettings.features.quickRegenerate);
 	},
 
 	/**	Enable/Disable the message generation error sound. */
-	playErrorSound: function () {
+	playErrorSound: function() {
 		if (
 			!extensionSettings.enabled ||
 			!extensionSettings.features.playErrorSound
@@ -254,7 +258,7 @@ const settingsCallbacks = {
 		forceUnable:
 		- If true, forces features.quickRegenerate to be disabled.
 	*/
-	zoomCharacterAvatar: function (forceUnable = false) {
+	zoomCharacterAvatar: function(forceUnable = false) {
 		const enableFeature = !forceUnable && extensionSettings.features.zoomCharacterAvatar;
 
 		setRootCSSVariables('--qol-zoomed-avatar-container-display', enableFeature ? 'flex' : 'none');
@@ -263,10 +267,16 @@ const settingsCallbacks = {
 		if (enableFeature) zoomCharacterAvatar();
 	},
 
-	showActivatedWiEntries: function () {
+	showActivatedWiEntries: function() {
 		const state = extensionSettings.features.showActivatedWiEntries;
 
 		if (!state) $('#qol-display-active-entries').remove();
+	},
+
+	preventPageNavigation: function() {
+		extensionSettings.features.preventPageNavigation && isMobile() ?
+			enableBackProtection() :
+			disableBackProtection();
 	}
 }
 
@@ -383,7 +393,7 @@ function getLocalStorageVar(var_name, {def_value = ''}) {
 	@returns Returns the original function, with the callback added.
 */
 function wrapMethod(originalFunction, callback) {
-	return function (...args) {
+	return function(...args) {
 		callback(args);
 		originalFunction.apply(this, args);
 	};
@@ -482,6 +492,31 @@ function simpleUserInput() {
 	log("simpleUserInput(): preventNextAbortSound ", preventNextAbortSound);
 }
 
+function enableBackProtection() {
+	history.pushState({guard: true}, '', location.href);
+	window.addEventListener('popstate', onPopState);
+	window.addEventListener('beforeunload', onBeforeUnload);
+}
+
+function disableBackProtection() {
+	window.removeEventListener('popstate', onPopState);
+	window.removeEventListener('beforeunload', onBeforeUnload);
+	history.replaceState(null, '', location.href);
+}
+
+function onPopState(e) {
+  	if (e.state && e.state.guard) {
+		history.pushState({guard: true}, '', location.href);
+		disableBackProtection();
+		history.back();
+  	}
+}
+
+function onBeforeUnload(e) {
+	e.preventDefault();
+	e.returnValue = '';
+}
+
 /**	Creates and insert any button provided by the extension. */
 async function loadQOLFeatures() {
     // Quick Regenerate
@@ -521,12 +556,12 @@ async function loadQOLFeatures() {
 		def_value: extensionSettings.features.zoomCharacterAvatar ? 'flex' : 'none'
 	}));
 
-	$('#qol-zoomed-avatar-close').on('click', function () {
+	$('#qol-zoomed-avatar-close').on('click', function() {
 		localStorage.setItem('qol-zoomed-avatar-display', 'none');
 		setRootCSSVariables('--qol-zoomed-avatar-container-display', 'none');
 	});
 
-	$('#chat').on('click', '.mes .avatar', function () {
+	$('#chat').on('click', '.mes .avatar', function() {
 		if (!extensionSettings.enabled || !extensionSettings.features.zoomCharacterAvatar) return;
 		localStorage.setItem('qol-zoomed-avatar-display', 'flex');
 		setRootCSSVariables('--qol-zoomed-avatar-container-display', 'flex');
@@ -846,53 +881,53 @@ function registerSlashCommands() {
 /** @type {Array<WIEntry>} */
 let activatedWiEntries = [];
 
-eventSource.on(eventTypes.CHAT_CHANGED, function (args) {
+eventSource.on(eventTypes.CHAT_CHANGED, function(args) {
 	log(eventTypes.CHAT_CHANGED, args);
 	hideRegenerateButton(false);
 	zoomCharacterAvatar();
 });
 
-eventSource.on(eventTypes.GENERATION_STARTED, function (args) {
+eventSource.on(eventTypes.GENERATION_STARTED, function(args) {
 	log(eventTypes.GENERATION_STARTED, args);
 	hideRegenerateButton();
 
 	activatedWiEntries = [];
 });
 
-eventSource.on(eventTypes.USER_MESSAGE_RENDERED, function (args) {
+eventSource.on(eventTypes.USER_MESSAGE_RENDERED, function(args) {
 	log(eventTypes.USER_MESSAGE_RENDERED, args);
 	hideRegenerateButton(false);
 	zoomCharacterAvatar();
 	simpleUserInput();
 });
 
-eventSource.on(eventTypes.CHARACTER_MESSAGE_RENDERED, function (args) {
+eventSource.on(eventTypes.CHARACTER_MESSAGE_RENDERED, function(args) {
 	log(eventTypes.CHARACTER_MESSAGE_RENDERED, args);
 	hideRegenerateButton(false);
 	zoomCharacterAvatar();
 });
 
-eventSource.on(eventTypes.MESSAGE_SWIPED, function (args) {
+eventSource.on(eventTypes.MESSAGE_SWIPED, function(args) {
 	log(eventTypes.MESSAGE_SWIPED, args);
 	hideRegenerateButton(false);
 });
 
-eventSource.on(eventTypes.MESSAGE_DELETED, function (args) {
+eventSource.on(eventTypes.MESSAGE_DELETED, function(args) {
 	log(eventTypes.MESSAGE_DELETED, args);
 	zoomCharacterAvatar();
 });
 
-eventSource.on(eventTypes.GENERATION_STOPPED, function (args) {
+eventSource.on(eventTypes.GENERATION_STOPPED, function(args) {
 	log(eventTypes.GENERATION_STOPPED, args);
 	hideRegenerateButton(false);
 });
 
-eventSource.on(eventTypes.GENERATION_ENDED, function (args) {
+eventSource.on(eventTypes.GENERATION_ENDED, function(args) {
 	log(eventTypes.GENERATION_ENDED, args);
 	hideRegenerateButton(false);
 });
 
-eventSource.makeFirst(eventTypes.GENERATE_AFTER_DATA, function (arg) {
+eventSource.makeFirst(eventTypes.GENERATE_AFTER_DATA, function(arg) {
     if (!extensionSettings.enabled) return;
 
     log(eventTypes.GENERATE_AFTER_DATA, arg);
@@ -919,7 +954,7 @@ eventSource.makeFirst(eventTypes.GENERATE_AFTER_DATA, function (arg) {
 	}
 });
 
-eventSource.makeFirst(eventTypes.CHAT_COMPLETION_SETTINGS_READY, function (arg) {
+eventSource.makeFirst(eventTypes.CHAT_COMPLETION_SETTINGS_READY, function(arg) {
     if (!extensionSettings.enabled) return;
 
 	log(eventTypes.CHAT_COMPLETION_SETTINGS_READY, arg);
@@ -966,7 +1001,7 @@ function getEntryIcon(entry) {
 	return icon;
 }
 
-eventSource.on(eventTypes.GENERATE_AFTER_COMBINE_PROMPTS, async function (args) {
+eventSource.on(eventTypes.GENERATE_AFTER_COMBINE_PROMPTS, async function(args) {
 	log(eventTypes.GENERATE_AFTER_COMBINE_PROMPTS, args);
 
 	if (!extensionSettings.enabled || !extensionSettings.features.showActivatedWiEntries) return;
@@ -1034,7 +1069,7 @@ eventSource.on(eventTypes.GENERATE_AFTER_COMBINE_PROMPTS, async function (args) 
 	}
 });
 
-eventSource.on(eventTypes.WORLDINFO_SCAN_DONE, function (/** @type {ScannedWIEntries} */ args) {
+eventSource.on(eventTypes.WORLDINFO_SCAN_DONE, function(/** @type {ScannedWIEntries} */ args) {
 	log(eventTypes.WORLDINFO_SCAN_DONE, args);
 
 	if (!extensionSettings.enabled || !extensionSettings.features.showActivatedWiEntries) return;
@@ -1043,7 +1078,7 @@ eventSource.on(eventTypes.WORLDINFO_SCAN_DONE, function (/** @type {ScannedWIEnt
 
 // * MARK:Initialize Extension
 
-$(async function () {
+eventSource.once(eventTypes.APP_INITIALIZED, async function() {
 	if (!context().extensionSettings[extensionName]) {
 	    context().extensionSettings[extensionName] = structuredClone(defaultSettings);
 	}

--- a/index.js
+++ b/index.js
@@ -972,9 +972,9 @@ eventSource.on(eventTypes.GENERATE_AFTER_COMBINE_PROMPTS, async function (args) 
 	if (!extensionSettings.enabled || !extensionSettings.features.showActivatedWiEntries) return;
 
 	const loreEntriesList = (await HTML_TEMPLATES.get("activatedLoreEntries")).clone();
-	const loreEntryGroupTemplate = $(loreEntriesList).find('.qol-activated-entry.template');
-	const loreEntryItemTemplate = $(loreEntriesList).find('.qol-activated-entry-item.template');
-	const currentList = $('#qol-activated-lore-entries-list');
+	const loreEntryGroupTemplate = $(loreEntriesList).find('.qol-activated-world.template');
+	const loreEntryItemTemplate = $(loreEntriesList).find('.qol-activated-entry.template');
+	const currentList = $('#qol-activated-worlds-list');
 
 	if (currentList.length) currentList.empty();
 
@@ -1001,7 +1001,7 @@ eventSource.on(eventTypes.GENERATE_AFTER_COMBINE_PROMPTS, async function (args) 
 
 		if (!entryGroup) {
 			entriesGroupedByWorld[worldID] = loreEntryGroupTemplate.clone().toggleClass('d-none', false).toggleClass('template', false);
-			entriesGroupedByWorld[worldID].find('.qol-activated-entry-world-name').html(lodash.escape(entry.world));
+			entriesGroupedByWorld[worldID].find('.qol-activated-world-name').html(lodash.escape(entry.world));
 
 			entryGroup = entriesGroupedByWorld[worldID];
 		}
@@ -1012,20 +1012,20 @@ eventSource.on(eventTypes.GENERATE_AFTER_COMBINE_PROMPTS, async function (args) 
 		entryItem.find('.qol-activated-entry-comment').html(lodash.escape(entry.comment));
 		entryItem.find('.qol-activated-entry-comment').prop('title', entry.comment);
 
-		entryGroup.find('.qol-activated-entry-world-entries').append(entryItem);
+		entryGroup.find('.qol-activated-world-entries').append(entryItem);
 	}
 
 	/** @type {Array<EntryGroup>} */
 	const entryGroups = Object.values(entriesGroupedByWorld);
 
 	for (const entryGroup of entryGroups)
-		loreEntriesList.find('#qol-activated-lore-entries-list').append(entryGroup);
+		loreEntriesList.find('#qol-activated-worlds-list').append(entryGroup);
 
-	loreEntriesList.find('.qol-activated-entry-item').last().toggleClass('separator-bottom-thin', false);
+	loreEntriesList.find('.qol-activated-entry').last().toggleClass('separator-bottom', false);
 
 	if (currentList.length) {
 		const newList = loreEntriesList
-			.find('#qol-activated-lore-entries-list')
+			.find('#qol-activated-worlds-list')
 			.children();
 
 		currentList.append(newList);

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
     "js": "index.js",
     "css": "style.css",
     "author": "Leandro Jofre",
-    "version": "0.7.2",
+    "version": "0.8.0",
     "minimum_client_version": "1.15.0",
     "homePage": "https://github.com/leandrojofre/SillyTavern-QOL.git",
     "auto_update": true

--- a/source/html/templates/activatedLoreEntries.html
+++ b/source/html/templates/activatedLoreEntries.html
@@ -6,18 +6,18 @@
 		</div>
 
         <div class="inline-drawer-content">
-            <div class="d-none qol-activated-entry template flex-container flex-column">
-                <b class="qol-activated-entry-world-name separator-bottom-thin"></b>
+            <div class="d-none qol-activated-world template flex-container flex-column">
+                <b class="qol-activated-world-name separator-bottom thin"></b>
 
-                <div class="qol-activated-entry-world-entries flex-container flex-column gap-5px p-0"></div>
+                <div class="qol-activated-world-entries flex-container flex-column gap-5px p-0"></div>
             </div>
 
-            <div class="d-none qol-activated-entry-item template flex-container gap-5px p-0 separator-bottom-thin">
+            <div class="d-none qol-activated-entry template flex-container gap-5px p-0 separator-bottom thin">
                 <span class="qol-activated-entry-icon"></span>
                 <div class="qol-activated-entry-comment"></div>
             </div>
 
-            <div id="qol-activated-lore-entries-list" class="flex-container flex-column"></div>
+            <div id="qol-activated-worlds-list" class="flex-container flex-column"></div>
         </div>
     </div>
 </div>

--- a/source/html/templates/settings.html
+++ b/source/html/templates/settings.html
@@ -36,6 +36,13 @@
 					<i class="right_menu_button fa-solid fa-circle-exclamation interactable" tabindex="0"></i>
 					<span>Show WI entries activated in the last generation</span>
 				</label>
+
+				<label class="flex-container" title="Made for mobile, it prevents closing the page if you accidentally press the &quot;got back&quot; button." data-i18n="[title]Made for mobile, it prevents closing the page if you accidentally press the &quot;got back&quot; button.">
+					<input id="qol-prevent-page-navigation" qol-setting="features/preventPageNavigation" type="checkbox" />
+					<i class="right_menu_button fa-solid fa-circle-exclamation interactable" tabindex="0"></i>
+					<i class="fa-solid fa-mobile-screen-button"></i>
+					<span>Prevent leaving the tab on go back gesture</span>
+				</label>
 			</div>
 
 			<div class="flex-container flex-column separator-bottom">

--- a/style.css
+++ b/style.css
@@ -107,6 +107,11 @@ div.zoomed_avatar:has(.zoomed_avatar_img) {
         border-radius: 0;
     }
 
+	.separator-bottom.thin {
+        padding-bottom: 0;
+        margin-bottom: 0;
+	}
+
     .border {
         border: 1px solid;
         border-color: var(--qol-border-color) !important;


### PR DESCRIPTION
## Changes
- A new toggle can be found in the extension settings menu to disable navigation on mobile.
> It prevents accidentally closing the page. **Warning**: most browser don't allow JavaScript to block navigation for security reasons, you will likely get a popup asking you to confirm leaving the page when the feature is enabled. Make sure the tab is allowed to create popups in the tab permissions for the SillyTavern url.
- Small background changes to the code